### PR TITLE
Allow request from any origin

### DIFF
--- a/anagram-random.c
+++ b/anagram-random.c
@@ -119,6 +119,7 @@ again:
 
 	puts("Status: 200 OK\r");
 	puts("Content-Type: application/json\r");
+	puts("Access-Control-Allow-Origin: *\r");
 	puts("\r");
 	printf("{\n\t\"letters\": \"%.*s\",\n\t\"center\": \"%c\",\n\t\"words\": %zu,\n\t\"total\": %zu,\n",
 		6, letters, letters[6], words, total);

--- a/anagram-today.c
+++ b/anagram-today.c
@@ -143,6 +143,7 @@ again:
 
 	puts("Status: 200 OK\r");
 	puts("Content-Type: application/json\r");
+	puts("Access-Control-Allow-Origin: *\r");
 	puts("\r");
 	printf("{\n\t\"letters\": \"%.*s\",\n\t\"center\": \"%c\",\n\t\"words\": %zu,\n\t\"total\": %zu,\n",
 		6, letters, letters[6], words, total);

--- a/anagram-yesterday.c
+++ b/anagram-yesterday.c
@@ -164,6 +164,7 @@ again:
 
 	puts("Status: 200 OK\r");
 	puts("Content-Type: application/json\r");
+	puts("Access-Control-Allow-Origin: *\r");
 	puts("\r");
 	printf("{\n\t\"letters\": \"%.*s\",\n\t\"center\": \"%c\",\n\t\"words\": %zu,\n\t\"total\": %zu,\n",
 		6, letters, letters[6], words, total);


### PR DESCRIPTION
Hello, 

I'm trying to use the API for a small project but I'm unable to use it due to the lack of a CORS header which prevents browsers from allowing requests to the API from different origins (i.e not from freebee.fun).

The following patch should add the proper CORS header which allows any origin.

Thanks!

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin